### PR TITLE
Фикс гетто газодобытчика

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/Shutter/shutters.yml
@@ -61,6 +61,7 @@
       type: WiresBoundUserInterface
   - type: Airtight
     fixVacuum: true
+    noAirWhenFullyAirBlocked: false
   - type: RadiationBlocker
     resistance: 2
   - type: Damageable


### PR DESCRIPTION
# Описание PR <!-- Опишите здесь ваш Pull Request. Что он изменяет? На что еще это может повлиять? -->
Дело было в AirtightComponent. Не знаю зачем ставням такое взаимодействие с атмосферой, но теперь оно повторяет шлюзы. Шлюзы запирают газ на тайле, на котором закрылись. Остальные поведения ставней вроде как не затронуты. 

## Чек-лист:

- [x] Rechecked all my code

## typo:

- [x] Fix

**Изменения**
Ставни и гермозатворы теперь работают как шлюзы, газ внутри них не "уничтожается" а запирается.

**Changelog**

:cl: MJ Sailor
- remove: Пофикшен гетто газодобытчик

