### PR TITLE
Buff hellfreezer min temp to 12.15 from 19.15

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
+++ b/Resources/Prototypes/Entities/Structures/Piping/Atmospherics/unary.yml
@@ -382,7 +382,7 @@
   - type: Sprite
     sprite: Structures/Piping/Atmospherics/hellfirethermomachine.rsi
   - type: GasThermoMachine
-    minTemperature: 19.15
+    minTemperature: 12.15
     heatCapacity: 40000
     energyLeakPercentage: 0.15
   - type: Machine


### PR DESCRIPTION
# Описание PR 
Buff hellfreezer min temp to 12.15, so atmosians can make hypernoblium
мне наплакались, не могут делать гиперноблий. если есть возражения по балансу, то пишите
## Чек-лист:

- [x] Rechecked all my code

## typo:

- [ ] Feature
- [ ] Fix
- [x] Tweak
- [ ] Balance

**Changelog**
:cl: MJ Sailor
- tweak: Минимальная температура хеллфризера понижена до 12.15K с 19.15K.