### PR TITLE
synthflesh nerf

### DIFF
--- a/Content.Client/GameTicking/Commands/ShowManifestCommand.cs
+++ b/Content.Client/GameTicking/Commands/ShowManifestCommand.cs
@@ -1,0 +1,28 @@
+﻿using Content.Client.GameTicking.Managers;
+using Content.Shared.Administration;
+using Robust.Shared.Console;
+
+namespace Content.Client.GameTicking.Commands;
+
+[AnyCommand]
+public sealed class ShowManifestCommand : IConsoleCommand
+{
+    [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
+    public string Command => "showmanifest";
+    public string Description => "Shows manifest if you closed one";
+    public string Help => "Usage: showmanifest";
+
+    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    {
+        var ticker = _entitySystem.GetEntitySystem<ClientGameTicker>();
+        var window = ticker._window;
+
+        if (window == null)
+        {
+            shell.WriteLine("This can only be executed while the game is not in a round.");
+            return;
+        }
+
+        window.OpenCentered();
+    }
+}

--- a/Content.Client/GameTicking/Commands/ShowManifestCommand.cs
+++ b/Content.Client/GameTicking/Commands/ShowManifestCommand.cs
@@ -1,28 +1,31 @@
 ﻿using Content.Client.GameTicking.Managers;
 using Content.Shared.Administration;
+using Content.Shared.GameTicking;
 using Robust.Shared.Console;
+using Robust.Shared.Network;
 
-namespace Content.Client.GameTicking.Commands;
-
-[AnyCommand]
-public sealed class ShowManifestCommand : IConsoleCommand
+namespace Content.Client.GameTicking.Commands
 {
-    [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
-    public string Command => "showmanifest";
-    public string Description => "Shows manifest if you closed one";
-    public string Help => "Usage: showmanifest";
-
-    public void Execute(IConsoleShell shell, string argStr, string[] args)
+    [AnyCommand]
+    public sealed class ShowManifestCommand : IConsoleCommand
     {
-        var ticker = _entitySystem.GetEntitySystem<ClientGameTicker>();
-        var window = ticker._window;
+        [Dependency] private readonly IEntitySystemManager _entitySystem = default!;
 
-        if (window == null)
+        public string Command => "showmanifest";
+        public string Description => "Shows round end summary window";
+        public string Help => "Usage: showmanifest";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
         {
-            shell.WriteLine("This can only be executed while the game is not in a round.");
-            return;
-        }
+            var ticker = _entitySystem.GetEntitySystem<ClientGameTicker>();
+            var window = ticker._window;
 
-        window.OpenCentered();
+            if (!ticker.IsGameStarted && window != null)
+            {
+                window.OpenCentered();
+                return;
+            }
+            shell.WriteLine("You can't open manifest right now");
+        }
     }
 }

--- a/Content.Client/GameTicking/Managers/ClientGameTicker.cs
+++ b/Content.Client/GameTicking/Managers/ClientGameTicker.cs
@@ -23,7 +23,7 @@ namespace Content.Client.GameTicking.Managers
         /// <summary>
         /// The current round-end window. Could be used to support re-opening the window after closing it.
         /// </summary>
-        private RoundEndSummaryWindow? _window;
+        public RoundEndSummaryWindow? _window;
 
         [ViewVariables] public bool AreWeReady { get; private set; }
         [ViewVariables] public bool IsGameStarted { get; private set; }

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -31,8 +31,7 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private readonly ReactiveSystem _reactive = default!;
 
         private const float ReactTime = 0.125f;
-        private readonly HashSet<(EntityUid, EntityUid)> _processedCollisions = new(); // WD edit
-
+        private HashSet<EntityUid> _processedCollisions = new(); // WD edit
 
         public override void Initialize()
         {
@@ -46,11 +45,8 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents))
                 return;
 
-            // WD edit start
-            var collisionPair = (Uid: entity.Owner, OtherUid: args.OtherEntity);
-            if (_processedCollisions.Contains(collisionPair))
+            if (_processedCollisions.Contains(args.OtherEntity)) // WD edit
                 return;
-            // WD edit end
 
             foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
             {
@@ -58,10 +54,12 @@ namespace Content.Server.Chemistry.EntitySystems
                 _reactive.DoEntityReaction(args.OtherEntity, solution, ReactionMethod.Touch);
             }
 
-            // WD edit start
-            _processedCollisions.Add(collisionPair);
 
-            Task.Delay(TimeSpan.FromSeconds(0.5)).ContinueWith(_ => _processedCollisions.Remove(collisionPair));
+            // WD edit start
+            var collision = args.OtherEntity;
+            _processedCollisions.Add(collision);
+
+            Task.Delay(TimeSpan.FromSeconds(0.5)).ContinueWith(_ => _processedCollisions.Remove(collision));
             // WD edit end
 
             // Check for collision with a impassable object (e.g. wall) and stop

--- a/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
+++ b/Content.Server/Chemistry/EntitySystems/VaporSystem.cs
@@ -31,7 +31,8 @@ namespace Content.Server.Chemistry.EntitySystems
         [Dependency] private readonly ReactiveSystem _reactive = default!;
 
         private const float ReactTime = 0.125f;
-        private HashSet<EntityUid> _processedCollisions = new(); // WD edit
+        private readonly HashSet<(EntityUid, EntityUid)> _processedCollisions = new(); // WD edit
+
 
         public override void Initialize()
         {
@@ -45,8 +46,11 @@ namespace Content.Server.Chemistry.EntitySystems
             if (!EntityManager.TryGetComponent(entity.Owner, out SolutionContainerManagerComponent? contents))
                 return;
 
-            if (_processedCollisions.Contains(args.OtherEntity)) // WD edit
+            // WD edit start
+            var collisionPair = (Uid: entity.Owner, OtherUid: args.OtherEntity);
+            if (_processedCollisions.Contains(collisionPair))
                 return;
+            // WD edit end
 
             foreach (var (_, soln) in _solutionContainerSystem.EnumerateSolutions((entity.Owner, contents)))
             {
@@ -54,12 +58,10 @@ namespace Content.Server.Chemistry.EntitySystems
                 _reactive.DoEntityReaction(args.OtherEntity, solution, ReactionMethod.Touch);
             }
 
-
             // WD edit start
-            var collision = args.OtherEntity;
-            _processedCollisions.Add(collision);
+            _processedCollisions.Add(collisionPair);
 
-            Task.Delay(TimeSpan.FromSeconds(0.5)).ContinueWith(_ => _processedCollisions.Remove(collision));
+            Task.Delay(TimeSpan.FromSeconds(0.5)).ContinueWith(_ => _processedCollisions.Remove(collisionPair));
             // WD edit end
 
             // Check for collision with a impassable object (e.g. wall) and stop

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -25,6 +25,7 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
 
         private const string ThrowingFixture = "throw-fixture";
+        private readonly HashSet<(EntityUid, EntityUid)> _processed = new (); // WD edit
 
         public override void Initialize()
         {
@@ -65,7 +66,14 @@ namespace Content.Shared.Throwing
             if (args.OtherEntity == component.Thrower)
                 return;
 
+            // WD edit start
+            var collisionPair = (uid, args.OtherEntity);
+            if (_processed.Contains(collisionPair))
+                return;
+            // WD edit end
+
             ThrowCollideInteraction(component, args.OurEntity, args.OtherEntity);
+            _processed.Add(collisionPair);
         }
 
         private void PreventCollision(EntityUid uid, ThrownItemComponent component, ref PreventCollideEvent args)
@@ -110,6 +118,7 @@ namespace Content.Shared.Throwing
 
             EntityManager.EventBus.RaiseLocalEvent(uid, new StopThrowEvent { User = thrownItemComponent.Thrower }, true);
             EntityManager.RemoveComponent<ThrownItemComponent>(uid);
+            _processed.Clear(); // WD edit
         }
 
         public void LandComponent(EntityUid uid, ThrownItemComponent thrownItem, PhysicsComponent physics, bool playSound)

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -1,5 +1,4 @@
 using System.Linq;
-using System.Threading.Tasks;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Gravity;
@@ -26,7 +25,6 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
 
         private const string ThrowingFixture = "throw-fixture";
-        private readonly HashSet<(EntityUid, EntityUid)> _processedCollisions = new(); // WD edit
 
         public override void Initialize()
         {
@@ -64,22 +62,10 @@ namespace Content.Shared.Throwing
             if (!args.OtherFixture.Hard)
                 return;
 
-            // WD edit start
-            var collisionPair = (Uid: uid, OtherUid: args.OtherEntity);
-            if (_processedCollisions.Contains(collisionPair))
-                return;
-            // WD edit start
-
             if (args.OtherEntity == component.Thrower)
                 return;
 
             ThrowCollideInteraction(component, args.OurEntity, args.OtherEntity);
-
-            // WD edit start
-            _processedCollisions.Add(collisionPair);
-
-            Task.Delay(TimeSpan.FromSeconds(0.5)).ContinueWith(_ => _processedCollisions.Remove(collisionPair));
-            // WD edit end
         }
 
         private void PreventCollision(EntityUid uid, ThrownItemComponent component, ref PreventCollideEvent args)

--- a/Content.Shared/Throwing/ThrownItemSystem.cs
+++ b/Content.Shared/Throwing/ThrownItemSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Content.Shared.Administration.Logs;
 using Content.Shared.Database;
 using Content.Shared.Gravity;
@@ -25,6 +26,7 @@ namespace Content.Shared.Throwing
         [Dependency] private readonly SharedGravitySystem _gravity = default!;
 
         private const string ThrowingFixture = "throw-fixture";
+        private readonly HashSet<(EntityUid, EntityUid)> _processedCollisions = new(); // WD edit
 
         public override void Initialize()
         {
@@ -62,10 +64,22 @@ namespace Content.Shared.Throwing
             if (!args.OtherFixture.Hard)
                 return;
 
+            // WD edit start
+            var collisionPair = (Uid: uid, OtherUid: args.OtherEntity);
+            if (_processedCollisions.Contains(collisionPair))
+                return;
+            // WD edit start
+
             if (args.OtherEntity == component.Thrower)
                 return;
 
             ThrowCollideInteraction(component, args.OurEntity, args.OtherEntity);
+
+            // WD edit start
+            _processedCollisions.Add(collisionPair);
+
+            Task.Delay(TimeSpan.FromSeconds(0.5)).ContinueWith(_ => _processedCollisions.Remove(collisionPair));
+            // WD edit end
         }
 
         private void PreventCollision(EntityUid uid, ThrownItemComponent component, ref PreventCollideEvent args)

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1089,6 +1089,7 @@
       - CarpetBlack
       - CarpetPink
       - CarpetBlue
+      - CarpetSBlue
       - CarpetGreen
       - CarpetOrange
       - CarpetPurple

--- a/Resources/Prototypes/Recipes/Lathes/clothing.yml
+++ b/Resources/Prototypes/Recipes/Lathes/clothing.yml
@@ -1249,6 +1249,13 @@
     Cloth: 100
 
 - type: latheRecipe
+  id: CarpetSBlue
+  result: FloorCarpetItemSkyBlue
+  completetime: 1
+  materials:
+    Cloth: 100
+
+- type: latheRecipe
   id: CarpetGreen
   result: FloorCarpetItemGreen
   completetime: 1

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -577,9 +577,12 @@
 
 - type: reaction
   id: Synthflesh
+  minTemp: 370
   reactants:
     Blood:
-      amount: 1
+      amount: 2
+    WeldingFuel:
+      amount: 2
     Carbon:
       amount: 1
     Bicaridine:


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->
Приколы
# Описание PR <!-- Опишите здесь ваш Pull Request. Что он изменяет? На что еще это может повлиять? -->

## Скриншоты
<!-- Если приемлемо, добавьте скриншоты для демонстрации вашего PR. Если ваш PR представляет собой визуальное изменение, добавьте
скриншоты, иначе он может быть закрыт. -->

## Чек-лист:

- [x] Rechecked all my code

## typo:

- [ ] Feature
- [ ] Fix
- [ ] Tweak
- [x] Balance

**Изменения**
<!--
Здесь вы можете написать список изменений, который будет автоматически добавлен в игру, когда ваш PR будет принят
Для записей в списке изменений есть 4 значка: add, remove, tweak, fix. Думаю, вы сможете разобраться с остальным.

Вы можете поставить свое имя после символа :cl:, чтобы изменить имя, которое будет отображаться в журнале изменений (в противном случае будет использоваться ваше имя пользователя GitHub)
Например: :cl: PJB

Как правило, в журналы изменений следует помещать только то, что действительно важно игрокам. Вещи вроде "Переработана система X, изменения не должны быть видны" не должны быть в журнале изменений.

При написании списка изменений не считайте суффикс типа записи (например, add) "частью" предложения:
плохо: - add: новый инструмент для инженеров
хорошо: - add: добавлен новый инструмент для инженеров
-->

**Changelog**
<!--
Make players aware of new features and changes that could affect how they play the game by adding a Changelog entry. Please read the Changelog guidelines located at: https://docs.spacestation14.io/en/getting-started/pr-guideline#changelog
-->

<!--
Make sure to take this Changelog template out of the comment block in order for it to show up.
:cl:
- add: Добавлено веселье!
- remove: Убрано веселье!
-->
:cl: RinKeeper
fix: Изменен рецепт синтеплоти, а также реагенты теперь нужно разогревать
fix: Теперь в принтере униформы есть небесно-голубой ковёр
fix: Огнетушитель и подобные ему теперь не могут за 1 прыск применить эффект дважды или трижды
fix: Теперь предметы в полете не срабатывают больше 1 раза
add: с помощью команды showmanifest теперь можно посмотреть манифест после раунда даже если вы его закрыли


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a command to display a manifest window in the game, accessible via the new `ShowManifestCommand` when not in a round.
  - Added the `CarpetSBlue` carpet color and a corresponding crafting recipe using 100 units of Cloth.

- **Enhancements**
  - Improved collision handling in both vapor and thrown item systems to prevent duplicate collisions.
  - Updated the `Synthflesh` reaction to require higher quantities of Blood and WeldingFuel and a minimum temperature of 370.

- **Bug Fixes**
  - Adjusted internal tracking mechanisms to handle despawn events and manage collision pairs more effectively.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->