### PR TITLE
[Fix] Исправление краша серверов через настольные игры

### DIFF
--- a/Content.Server/Tabletop/Components/TabletopGameComponent.cs
+++ b/Content.Server/Tabletop/Components/TabletopGameComponent.cs
@@ -37,5 +37,19 @@ namespace Content.Server.Tabletop.Components
         /// </summary>
         [ViewVariables]
         public TabletopSession? Session { get; set; } = null;
+        
+        // Skyedra Fix start
+        /// <summary>
+        /// How many holograms have been spawned onto this board.
+        /// </summary>
+        [ViewVariables]
+        public int HologramsSpawned { get; set; } = 0;
+
+        /// <summary>
+        /// How many holograms are allowed to be spawned total by players.
+        /// </summary>
+        [ViewVariables]
+        public int MaximumHologramsAllowed { get; set; } = 10;
+        // Skyedra Fix end
     }
 }

--- a/Content.Server/Tabletop/TabletopSystem.cs
+++ b/Content.Server/Tabletop/TabletopSystem.cs
@@ -68,6 +68,9 @@ namespace Content.Server.Tabletop
             // Find the entity, remove it from the session and set it's position to the tabletop
             session.Entities.TryGetValue(entity, out var result);
             session.Entities.Remove(result);
+
+            tabletop.HologramsSpawned--; // White Dream fix
+
             QueueDel(result);
         }
 
@@ -90,6 +93,16 @@ namespace Content.Server.Tabletop
             if (!TryComp<ItemComponent>(handEnt, out var item))
                 return;
 
+            // Skye hotfix to prevent people from infinitely spawning mice on the board games and crashing server.
+            if (component.HologramsSpawned >= component.MaximumHologramsAllowed)
+            {
+                _popupSystem.PopupEntity(Loc.GetString("tabletop-max-entities"), uid, args.User);
+                return;
+            }
+
+            component.HologramsSpawned++;
+            // Skye hotfix end
+            
             var meta = MetaData(handEnt);
             var protoId = meta.EntityPrototype?.ID;
 

--- a/Resources/Locale/en-US/tabletop/tabletop.ftl
+++ b/Resources/Locale/en-US/tabletop/tabletop.ftl
@@ -4,6 +4,7 @@ tabletop-verb-dump-pieces = Dump Pieces
 tabletop-default-board-name = Board Game
 tabletop-error-remove-non-hologram = You cant remove a built in piece!
 tabletop-added-piece = The board shimmers brightly!
+tabletop-max-entities = Maximum number of holograms placed.
 
 ## Chess
 tabletop-chess-board-name = Chess

--- a/Resources/Locale/ru-RU/tabletop/tabletop.ftl
+++ b/Resources/Locale/ru-RU/tabletop/tabletop.ftl
@@ -5,6 +5,7 @@ tabletop-verb-dump-pieces = Сбросить куски
 tabletop-default-board-name = Настольная игра
 tabletop-error-remove-non-hologram = Вы не можете удалить встроенный элемент!
 tabletop-added-piece = Доска ярко переливается!
+tabletop-max-entities = Максимальное количество голограмм уже поставлено.
 
 ## Chess
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR <!-- Опишите здесь ваш Pull Request. Что он изменяет? На что еще это может повлиять? -->

## **Изменения**

:cl: Skyedra & Remuchi 
- fix: Исправлен краш серверов через настольные игры.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added functionality for managing holograms on the tabletop.
    - Introduced properties to track the number of holograms spawned and the maximum allowed holograms.
    - Adjusted entity interactions on the tabletop to prevent server crashes.

- **Localization**
    - Added a new localization key for informing users about the maximum number of entities that can be placed in English and Russian.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->