### PR TITLE
[CVAR] Stalin always Enabled + Time to reg. 

### DIFF
--- a/Content.Server/_White/Stalin/StalinManager.cs
+++ b/Content.Server/_White/Stalin/StalinManager.cs
@@ -37,7 +37,7 @@ public sealed class StalinManager
     private readonly Dictionary<string, DateTime> _nextStalinAllowedCheck = new();
     private string _stalinApiUrl = string.Empty;
     private string _stalinAuthUrl = string.Empty;
-    private float _minimalDiscordAccountAge = 228f;
+    private float _minimalDiscordAccountAge = 10080f;
 
     public void Initialize()
     {

--- a/Content.Shared/_White/WhiteCVars.cs
+++ b/Content.Shared/_White/WhiteCVars.cs
@@ -138,9 +138,9 @@ public sealed class WhiteCVars
     public static readonly CVarDef<string> StalinAuthUrl =
         CVarDef.Create("stalin.auth_url", string.Empty, CVar.SERVERONLY | CVar.CONFIDENTIAL | CVar.ARCHIVE);
     public static readonly CVarDef<bool> StalinEnabled =
-        CVarDef.Create("stalin.enabled", false, CVar.SERVERONLY | CVar.ARCHIVE);
+        CVarDef.Create("stalin.enabled", true, CVar.SERVERONLY | CVar.ARCHIVE);
     public static readonly CVarDef<float> StalinDiscordMinimumAge =
-        CVarDef.Create("stalin.minimal_discord_age_minutes", 1440.0f, CVar.SERVERONLY | CVar.ARCHIVE);
+        CVarDef.Create("stalin.minimal_discord_age_minutes", 10080.0f, CVar.SERVERONLY | CVar.ARCHIVE);
 
 
     /*


### PR DESCRIPTION
Чтобы жизнь мёдом не казалась.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The "Stalin" feature is now enabled by default, enhancing user engagement.
  
- **Changes**
	- The minimum age requirement for Discord accounts has increased from 24 hours to 7 days, enforcing stricter eligibility criteria for access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->