### PR TITLE
Добавил параметр группы для некоторых реагентов

### DIFF
--- a/Resources/Locale/en-US/guidebook/guides.ftl
+++ b/Resources/Locale/en-US/guidebook/guides.ftl
@@ -29,6 +29,7 @@ guide-entry-toxins = Toxins
 guide-entry-foods = Foods
 guide-entry-biological = Biological
 guide-entry-others = Others
+guide-entry-cleaning = Cleaning
 guide-entry-botanical = Botanicals
 guide-entry-ss14 = Space Station 14
 guide-entry-janitorial = Janitorial

--- a/Resources/Prototypes/Guidebook/chemicals.yml
+++ b/Resources/Prototypes/Guidebook/chemicals.yml
@@ -12,6 +12,7 @@
   - Botanical
   - Biological
   - Others
+  - Cleaning # WD
   filterEnabled: True
 
 - type: guideEntry
@@ -61,3 +62,9 @@
   name: guide-entry-others
   text: "/ServerInfo/Guidebook/ChemicalTabs/Other.xml"
   filterEnabled: True
+
+- type: guideEntry # WD edit start
+  id: Cleaning
+  name: guide-entry-cleaning
+  text: "/ServerInfo/Guidebook/ChemicalTabs/Cleaning.xml"
+  filterEnabled: True # WD edit end

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -1,6 +1,7 @@
 - type: reagent
   id: Bleach
   name: reagent-name-bleach
+  group: Cleaning # WD
   desc: reagent-desc-bleach
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
@@ -27,6 +28,7 @@
 - type: reagent
   id: SpaceCleaner
   name: reagent-name-space-cleaner
+  group: Cleaning # WD
   desc: reagent-desc-space-cleaner
   physicalDesc: reagent-physical-desc-lemony-fresh
   flavor: bitter
@@ -45,6 +47,7 @@
 - type: reagent
   id: SoapReagent
   name: reagent-name-soap
+  group: Cleaning # WD
   desc: reagent-desc-soap
   physicalDesc: reagent-physical-desc-soapy
   flavor: clean
@@ -71,6 +74,7 @@
 - type: reagent
   id: SpaceLube
   name: reagent-name-space-lube
+  group: Cleaning # WD
   desc: reagent-desc-space-lube
   slippery: true
   physicalDesc: reagent-physical-desc-shiny
@@ -89,6 +93,7 @@
 - type: reagent
   id: SpaceGlue
   name: reagent-name-space-glue
+  group: Cleaning # WD
   desc: reagent-desc-space-glue
   physicalDesc: reagent-physical-desc-sticky
   flavor: glue

--- a/Resources/Prototypes/Reagents/cleaning.yml
+++ b/Resources/Prototypes/Reagents/cleaning.yml
@@ -1,6 +1,7 @@
 - type: reagent
   id: Bleach
   name: reagent-name-bleach
+  group: Special # WD
   desc: reagent-desc-bleach
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
@@ -27,6 +28,7 @@
 - type: reagent
   id: SpaceCleaner
   name: reagent-name-space-cleaner
+  group: Special # WD
   desc: reagent-desc-space-cleaner
   physicalDesc: reagent-physical-desc-lemony-fresh
   flavor: bitter
@@ -45,6 +47,7 @@
 - type: reagent
   id: SoapReagent
   name: reagent-name-soap
+  group: Special # WD
   desc: reagent-desc-soap
   physicalDesc: reagent-physical-desc-soapy
   flavor: clean
@@ -71,6 +74,7 @@
 - type: reagent
   id: SpaceLube
   name: reagent-name-space-lube
+  group: Special # WD
   desc: reagent-desc-space-lube
   slippery: true
   physicalDesc: reagent-physical-desc-shiny
@@ -89,6 +93,7 @@
 - type: reagent
   id: SpaceGlue
   name: reagent-name-space-glue
+  group: Special # WD
   desc: reagent-desc-space-glue
   physicalDesc: reagent-physical-desc-sticky
   flavor: glue

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -1,7 +1,7 @@
 - type: reagent
   id: Carpetium
   name: reagent-name-carpetium
-  group: Special
+  group: Unknown # WD
   desc: reagent-desc-carpetium
   physicalDesc: reagent-physical-desc-fibrous
   flavor: carpet
@@ -30,6 +30,7 @@
 - type: reagent
   id: Fiber
   name: reagent-name-fiber
+  group: Unknown # WD
   desc: reagent-desc-fiber
   physicalDesc: reagent-physical-desc-fibrous
   flavor: fiber
@@ -139,6 +140,7 @@
 - type: reagent
   id: GroundBee
   name: reagent-name-ground-bee
+  group: Unknown # WD
   desc: reagent-desc-ground-bee
   physicalDesc: reagent-physical-desc-bee-guts
   flavor: bee
@@ -147,6 +149,7 @@
 - type: reagent
   id: Saxoite
   name: reagent-name-saxoite
+  group: Toxins # WD
   desc: reagent-desc-saxoite
   physicalDesc: reagent-physical-desc-ground-brass
   flavor: sax
@@ -300,7 +303,7 @@
 - type: reagent
   id: Laughter
   name: reagent-name-laughter
-  group: Special
+  group: Unknown # WD
   desc: reagent-desc-laughter
   physicalDesc: reagent-physical-desc-funny
   flavor: funny

--- a/Resources/Prototypes/Reagents/fun.yml
+++ b/Resources/Prototypes/Reagents/fun.yml
@@ -30,6 +30,7 @@
 - type: reagent
   id: Fiber
   name: reagent-name-fiber
+  group: Special # WD
   desc: reagent-desc-fiber
   physicalDesc: reagent-physical-desc-fibrous
   flavor: fiber
@@ -139,6 +140,7 @@
 - type: reagent
   id: GroundBee
   name: reagent-name-ground-bee
+  group: Special # WD
   desc: reagent-desc-ground-bee
   physicalDesc: reagent-physical-desc-bee-guts
   flavor: bee
@@ -147,6 +149,7 @@
 - type: reagent
   id: Saxoite
   name: reagent-name-saxoite
+  group: Toxins # WD
   desc: reagent-desc-saxoite
   physicalDesc: reagent-physical-desc-ground-brass
   flavor: sax

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1217,6 +1217,7 @@
 - type: reagent
   id: Synthflesh
   name: reagent-name-synthflesh
+  group: Medicine # WD
   desc: reagent-desc-synthflesh
   flavor: metallic
   physicalDesc: reagent-physical-desc-gelatinous
@@ -1247,6 +1248,7 @@
 - type: reagent
   id: SilverSulfadiazine
   name: reagent-name-silversulfadiazine
+  group: Medicine # WD
   desc: reagent-desc-silversulfadiazine
   flavor: medicine
   physicalDesc: reagent-physical-desc-creamy
@@ -1273,6 +1275,7 @@
 - type: reagent
   id: StypticPowder
   name: reagent-name-stypticpowder
+  group: Medicine # WD
   desc: reagent-desc-stypticpowder
   flavor: medicine
   physicalDesc: reagent-physical-desc-powdery

--- a/Resources/ServerInfo/Guidebook/ChemicalTabs/Cleaning.xml
+++ b/Resources/ServerInfo/Guidebook/ChemicalTabs/Cleaning.xml
@@ -1,0 +1,8 @@
+<Document>
+# Cleaning
+
+The chemicals on this list make your station white. Don't drink!
+
+<GuideReagentGroupEmbed Group="Cleaning"/>
+
+</Document>

--- a/Resources/ServerInfo/Guidebook/Chemicals.xml
+++ b/Resources/ServerInfo/Guidebook/Chemicals.xml
@@ -1,4 +1,4 @@
-﻿<Document>
+<Document>
 # Chemicals
 
 Chemicals are a powerful tool that can cause a variety of effects when consumed. Some can be found in plants, purchased from cargo, or be synthesized through combination with other chemicals.
@@ -31,4 +31,8 @@ Knowing different types of chemicals and their effects is important for being ab
 
 ## Other
 <GuideReagentGroupEmbed Group="Unknown"/>
+
+## Cleaning
+<GuideReagentGroupEmbed Group="Cleaning"/> <!--WD-->
+
 </Document>


### PR DESCRIPTION
Изменено:

-add: новый раздел "Cleaning" в руководство;
-fix: добавлен параметр группы для некоторых реагентов, несуществующий параметр Special заменён.

У пиротехники параметр наследуется. Трогать не стал.
В Cleaning.xml нет пометки WD - комментарий ломает файл.
В ftl файле добавлена 32 строка - комментарии не работают.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new `group` attribute to various reagents, enhancing organization and classification.
  - Reagents `Bleach`, `SpaceCleaner`, `SoapReagent`, `SpaceLube`, and `SpaceGlue` are now categorized under "Cleaning".
  - Updated `group` classifications for `Carpetium`, `Fiber`, and `Laughter` to "Unknown", while `Saxoite` is now categorized under "Toxins".
  - Added a new "Cleaning" category to the guidebook, improving user navigation and access to information.
  - Introduced a new document detailing cleaning chemicals, including safety information and usage guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->