### PR TITLE
Stalin CVAR Increased

### DIFF
--- a/Content.Shared/_White/WhiteCVars.cs
+++ b/Content.Shared/_White/WhiteCVars.cs
@@ -140,7 +140,7 @@ public sealed class WhiteCVars
     public static readonly CVarDef<bool> StalinEnabled =
         CVarDef.Create("stalin.enabled", true, CVar.SERVERONLY | CVar.ARCHIVE);
     public static readonly CVarDef<float> StalinDiscordMinimumAge =
-        CVarDef.Create("stalin.minimal_discord_age_minutes", 10080.0f, CVar.SERVERONLY | CVar.ARCHIVE);
+        CVarDef.Create("stalin.minimal_discord_age_minutes", 604800.0f, CVar.SERVERONLY | CVar.ARCHIVE);
 
 
     /*


### PR DESCRIPTION
Я не могу проверить какие данные подтягиваются при проверке возраста аккаунта.
Но не думаю что пиздят и там реально секунды, а не минуты - https://discord.com/channels/891624095630909493/1271474467809263737/1271474467809263737 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the minimum age requirement for the "Stalin" feature to reflect a new interpretation based on Discord account age, potentially impacting user eligibility.
  
- **Bug Fixes**
	- Adjusted the age limit calculation to ensure consistent application of server rules related to Discord account age.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->