### PR TITLE
WhiteMoose 0 (null) entity fix

### DIFF
--- a/Resources/Maps/Misc/terminal.yml
+++ b/Resources/Maps/Misc/terminal.yml
@@ -12418,8 +12418,6 @@ entities:
       pos: 0.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#1E90FFFF'
 - proto: GasVentScrubber
@@ -12687,8 +12685,6 @@ entities:
       pos: 0.5,19.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#B22222FF'
 - proto: GeneratorBasic15kW

--- a/Resources/Maps/White/WhiteMoose.yml
+++ b/Resources/Maps/White/WhiteMoose.yml
@@ -12856,8 +12856,6 @@ entities:
       pos: -44.5,-10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
   - uid: 7019
@@ -12867,8 +12865,6 @@ entities:
       pos: -30.5,-10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12938
   - uid: 7020
@@ -12878,8 +12874,6 @@ entities:
       pos: -9.5,-12.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13393
   - uid: 7021
@@ -42209,8 +42203,6 @@ entities:
     components:
     - type: Transform
       parent: 14256
-    - type: SuitSensor
-      station: invalid
       mode: SensorBinary
     - type: DeviceNetwork
       address: 5647-FDA3
@@ -47617,15 +47609,6 @@ entities:
     - type: Transform
       pos: 7.593604,-4.2226486
       parent: 2
-- proto: EightAimModule
-  entities:
-  - uid: 8786
-    components:
-    - type: Transform
-      parent: 5696
-    - type: Physics
-      canCollide: False
-    - type: InsideEntityStorage
 - proto: EmergencyLight
   entities:
   - uid: 6413
@@ -48668,8 +48651,6 @@ entities:
       pos: -9.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5662
   - uid: 7977
@@ -48678,8 +48659,6 @@ entities:
       pos: -13.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5662
 - proto: FirelockGlass
@@ -48691,8 +48670,6 @@ entities:
       pos: 20.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12949
       - 12951
@@ -48703,8 +48680,6 @@ entities:
       pos: 20.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12949
       - 12951
@@ -48714,8 +48689,6 @@ entities:
       pos: -2.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
       - 12957
@@ -48732,8 +48705,6 @@ entities:
       pos: 20.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12949
       - 12951
@@ -48744,8 +48715,6 @@ entities:
       pos: 21.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12951
   - uid: 40
@@ -48755,8 +48724,6 @@ entities:
       pos: -23.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12963
@@ -48767,8 +48734,6 @@ entities:
       pos: -22.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 5662
@@ -48779,8 +48744,6 @@ entities:
       pos: -22.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 5662
@@ -48790,8 +48753,6 @@ entities:
       pos: -52.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
       - 12973
@@ -48801,8 +48762,6 @@ entities:
       pos: -35.5,-33.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12927
       - 12967
@@ -48812,8 +48771,6 @@ entities:
       pos: -51.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
       - 12973
@@ -48824,8 +48781,6 @@ entities:
       pos: -23.5,16.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12932
   - uid: 154
@@ -48834,8 +48789,6 @@ entities:
       pos: -23.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12927
       - 12962
@@ -48845,8 +48798,6 @@ entities:
       pos: -22.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12927
       - 12962
@@ -48857,8 +48808,6 @@ entities:
       pos: -22.5,-17.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12963
       - 12962
@@ -48869,8 +48818,6 @@ entities:
       pos: -23.5,-17.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12963
       - 12962
@@ -48881,8 +48828,6 @@ entities:
       pos: -24.5,-17.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12963
       - 12962
@@ -48893,8 +48838,6 @@ entities:
       pos: -24.5,16.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12932
   - uid: 174
@@ -48903,8 +48846,6 @@ entities:
       pos: -35.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12927
       - 12967
@@ -48921,8 +48862,6 @@ entities:
       pos: -2.5,5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
   - uid: 186
@@ -48932,8 +48871,6 @@ entities:
       pos: -24.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12963
@@ -48944,8 +48881,6 @@ entities:
       pos: -22.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 5662
@@ -48956,8 +48891,6 @@ entities:
       pos: -3.5,5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
   - uid: 224
@@ -48972,8 +48905,6 @@ entities:
       pos: -35.5,-34.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
   - uid: 307
@@ -49022,8 +48953,6 @@ entities:
       pos: -2.5,-20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12954
       - 12957
@@ -49033,8 +48962,6 @@ entities:
       pos: -3.5,-20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12954
       - 12957
@@ -49044,8 +48971,6 @@ entities:
       pos: -4.5,-20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12954
       - 12957
@@ -49062,8 +48987,6 @@ entities:
       pos: -30.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12976
@@ -49074,8 +48997,6 @@ entities:
       pos: 2.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
       - 12949
@@ -49086,8 +49007,6 @@ entities:
       pos: 2.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
       - 12949
@@ -49098,8 +49017,6 @@ entities:
       pos: -4.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5662
       - 12946
@@ -49110,8 +49027,6 @@ entities:
       pos: -4.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5662
       - 12946
@@ -49122,8 +49037,6 @@ entities:
       pos: -30.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12976
@@ -49134,8 +49047,6 @@ entities:
       pos: -30.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12976
@@ -49146,8 +49057,6 @@ entities:
       pos: -52.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12976
       - 12978
@@ -49158,8 +49067,6 @@ entities:
       pos: -52.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12976
       - 12978
@@ -49170,8 +49077,6 @@ entities:
       pos: -52.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12976
       - 12978
@@ -49182,8 +49087,6 @@ entities:
       pos: -24.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12932
@@ -49194,8 +49097,6 @@ entities:
       pos: -23.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
       - 12932
@@ -49205,8 +49106,6 @@ entities:
       pos: -3.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
       - 12957
@@ -49217,8 +49116,6 @@ entities:
       pos: 2.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
       - 12949
@@ -49229,8 +49126,6 @@ entities:
       pos: 34.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12951
   - uid: 1330
@@ -49240,8 +49135,6 @@ entities:
       pos: 35.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12951
   - uid: 1331
@@ -49251,8 +49144,6 @@ entities:
       pos: 22.5,1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12951
   - uid: 1476
@@ -49262,8 +49153,6 @@ entities:
       pos: -4.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5662
       - 12946
@@ -49350,8 +49239,6 @@ entities:
       pos: -60.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
   - uid: 6333
@@ -49558,8 +49445,6 @@ entities:
       pos: -28.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
   - uid: 7009
@@ -49569,8 +49454,6 @@ entities:
       pos: -27.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12934
   - uid: 7010
@@ -49646,8 +49529,6 @@ entities:
       pos: -5.5,-10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12957
   - uid: 7029
@@ -49657,8 +49538,6 @@ entities:
       pos: -5.5,-9.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12957
   - uid: 7030
@@ -49692,8 +49571,6 @@ entities:
       pos: -5.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12957
   - uid: 7035
@@ -49703,8 +49580,6 @@ entities:
       pos: -5.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12957
   - uid: 7036
@@ -49714,8 +49589,6 @@ entities:
       pos: -5.5,-4.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12957
   - uid: 7037
@@ -49725,8 +49598,6 @@ entities:
       pos: -5.5,-3.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12957
   - uid: 7038
@@ -49861,8 +49732,6 @@ entities:
       pos: -4.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12954
       - 12927
@@ -49872,8 +49741,6 @@ entities:
       pos: -3.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12954
       - 12927
@@ -49883,8 +49750,6 @@ entities:
       pos: -2.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12954
       - 12927
@@ -49894,8 +49759,6 @@ entities:
       pos: -24.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12927
       - 12962
@@ -49905,8 +49768,6 @@ entities:
       pos: -64.5,-1.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12978
       - 5989
@@ -49916,8 +49777,6 @@ entities:
       pos: -64.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12978
       - 5989
@@ -49927,8 +49786,6 @@ entities:
       pos: -64.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12978
       - 5989
@@ -49939,8 +49796,6 @@ entities:
       pos: -41.5,-36.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
   - uid: 8601
@@ -49950,8 +49805,6 @@ entities:
       pos: -43.5,-36.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
   - uid: 8733
@@ -50018,8 +49871,6 @@ entities:
       pos: 0.5,-2.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12946
   - uid: 12948
@@ -50046,8 +49897,6 @@ entities:
       pos: -28.5,-32.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12927
   - uid: 12964
@@ -50057,8 +49906,6 @@ entities:
       pos: -25.5,-21.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12962
   - uid: 12965
@@ -50074,8 +49921,6 @@ entities:
       pos: -21.5,-24.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12962
   - uid: 12970
@@ -50085,8 +49930,6 @@ entities:
       pos: -60.5,-33.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
   - uid: 12971
@@ -50096,8 +49939,6 @@ entities:
       pos: -57.5,-36.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12967
   - uid: 12972
@@ -50107,8 +49948,6 @@ entities:
       pos: -53.5,-20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12973
   - uid: 12980
@@ -64200,8 +64039,6 @@ entities:
       pos: -24.5,-30.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12961
     - type: AtmosPipeColor
@@ -64246,8 +64083,6 @@ entities:
       pos: -24.5,8.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5661
     - type: AtmosPipeColor
@@ -64258,8 +64093,6 @@ entities:
       pos: -23.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5661
     - type: AtmosPipeColor
@@ -64303,8 +64136,6 @@ entities:
       pos: -2.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12945
     - type: AtmosPipeColor
@@ -64316,8 +64147,6 @@ entities:
       pos: -3.5,12.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12945
     - type: AtmosPipeColor
@@ -64329,8 +64158,6 @@ entities:
       pos: 29.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12950
     - type: AtmosPipeColor
@@ -64342,8 +64169,6 @@ entities:
       pos: 14.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12950
     - type: AtmosPipeColor
@@ -64355,8 +64180,6 @@ entities:
       pos: 0.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12935
     - type: AtmosPipeColor
@@ -64368,8 +64191,6 @@ entities:
       pos: -68.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8042
     - type: AtmosPipeColor
@@ -64381,8 +64202,6 @@ entities:
       pos: -57.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8042
     - type: AtmosPipeColor
@@ -64394,8 +64213,6 @@ entities:
       pos: -46.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12975
     - type: AtmosPipeColor
@@ -64407,8 +64224,6 @@ entities:
       pos: -33.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12975
     - type: AtmosPipeColor
@@ -64420,8 +64235,6 @@ entities:
       pos: -24.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 241
     - type: AtmosPipeColor
@@ -64433,8 +64246,6 @@ entities:
       pos: -11.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12944
     - type: AtmosPipeColor
@@ -64445,8 +64256,6 @@ entities:
       pos: -2.5,-8.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12953
     - type: AtmosPipeColor
@@ -64457,8 +64266,6 @@ entities:
       pos: -2.5,-24.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12953
     - type: AtmosPipeColor
@@ -64470,8 +64277,6 @@ entities:
       pos: -63.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12984
     - type: AtmosPipeColor
@@ -64483,8 +64288,6 @@ entities:
       pos: -40.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12968
     - type: AtmosPipeColor
@@ -64496,8 +64299,6 @@ entities:
       pos: -29.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12959
     - type: AtmosPipeColor
@@ -64509,8 +64310,6 @@ entities:
       pos: -10.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12959
     - type: AtmosPipeColor
@@ -64533,8 +64332,6 @@ entities:
       pos: -57.5,-38.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12983
     - type: AtmosPipeColor
@@ -64545,8 +64342,6 @@ entities:
       pos: -52.5,-19.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12974
     - type: AtmosPipeColor
@@ -64557,8 +64352,6 @@ entities:
       pos: -52.5,-26.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12974
     - type: AtmosPipeColor
@@ -64570,8 +64363,6 @@ entities:
       pos: -24.5,-22.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12961
     - type: AtmosPipeColor
@@ -64583,8 +64374,6 @@ entities:
       pos: -24.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12961
     - type: AtmosPipeColor
@@ -64640,8 +64429,6 @@ entities:
       pos: -18.5,-23.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12995
     - type: AtmosPipeColor
@@ -64653,8 +64440,6 @@ entities:
       pos: -7.5,-23.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12995
     - type: AtmosPipeColor
@@ -64760,8 +64545,6 @@ entities:
       pos: -20.5,-37.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12959
     - type: AtmosPipeColor
@@ -64773,8 +64556,6 @@ entities:
       pos: -60.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12981
     - type: AtmosPipeColor
@@ -64793,8 +64574,6 @@ entities:
       pos: -9.5,-9.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13393
     - type: AtmosPipeColor
@@ -64806,8 +64585,6 @@ entities:
       pos: -14.5,-13.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 4024
@@ -64817,8 +64594,6 @@ entities:
       pos: -27.5,-9.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12938
     - type: AtmosPipeColor
@@ -64830,8 +64605,6 @@ entities:
       pos: -32.5,-21.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12939
     - type: AtmosPipeColor
@@ -64842,8 +64615,6 @@ entities:
       pos: -37.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
     - type: AtmosPipeColor
@@ -64854,8 +64625,6 @@ entities:
       pos: -46.5,-7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
     - type: AtmosPipeColor
@@ -64878,8 +64647,6 @@ entities:
       pos: -46.5,-14.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12921
     - type: AtmosPipeColor
@@ -64957,8 +64724,6 @@ entities:
       pos: -50.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12968
     - type: AtmosPipeColor
@@ -64998,8 +64763,6 @@ entities:
       pos: -47.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
     - type: AtmosPipeColor
@@ -65010,8 +64773,6 @@ entities:
       pos: 22.5,15.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12952
     - type: AtmosPipeColor
@@ -65023,8 +64784,6 @@ entities:
       pos: 17.5,14.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12952
     - type: AtmosPipeColor
@@ -65036,8 +64795,6 @@ entities:
       pos: -43.5,-37.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12982
     - type: AtmosPipeColor
@@ -65065,8 +64822,6 @@ entities:
       pos: -82.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8046
     - type: AtmosPipeColor
@@ -65078,8 +64833,6 @@ entities:
       pos: -81.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8046
     - type: AtmosPipeColor
@@ -65090,8 +64843,6 @@ entities:
       pos: -81.5,4.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8046
     - type: AtmosPipeColor
@@ -65103,8 +64854,6 @@ entities:
       pos: -89.5,-34.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12994
     - type: AtmosPipeColor
@@ -65127,8 +64876,6 @@ entities:
       pos: -41.5,-15.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12929
     - type: AtmosPipeColor
@@ -65139,8 +64886,6 @@ entities:
       pos: -30.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12937
     - type: AtmosPipeColor
@@ -65163,8 +64908,6 @@ entities:
       pos: -6.5,-4.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13390
     - type: AtmosPipeColor
@@ -65217,8 +64960,6 @@ entities:
       pos: 5.5,23.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -65230,8 +64971,6 @@ entities:
       pos: 4.5,30.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -65243,8 +64982,6 @@ entities:
       pos: 5.5,37.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -65255,8 +64992,6 @@ entities:
       pos: 5.5,33.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -65281,8 +65016,6 @@ entities:
       pos: -58.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8042
     - type: AtmosPipeColor
@@ -65315,8 +65048,6 @@ entities:
       pos: -23.5,11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5661
     - type: AtmosPipeColor
@@ -65350,8 +65081,6 @@ entities:
       pos: -2.5,13.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12945
     - type: AtmosPipeColor
@@ -65363,8 +65092,6 @@ entities:
       pos: 13.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12950
     - type: AtmosPipeColor
@@ -65376,8 +65103,6 @@ entities:
       pos: -0.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12935
     - type: AtmosPipeColor
@@ -65389,8 +65114,6 @@ entities:
       pos: -12.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12944
     - type: AtmosPipeColor
@@ -65402,8 +65125,6 @@ entities:
       pos: -25.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 241
     - type: AtmosPipeColor
@@ -65415,8 +65136,6 @@ entities:
       pos: -34.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12975
     - type: AtmosPipeColor
@@ -65428,8 +65147,6 @@ entities:
       pos: -47.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12975
     - type: AtmosPipeColor
@@ -65441,8 +65158,6 @@ entities:
       pos: -69.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8042
     - type: AtmosPipeColor
@@ -65454,8 +65169,6 @@ entities:
       pos: 28.5,-0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12950
     - type: AtmosPipeColor
@@ -65483,8 +65196,6 @@ entities:
       pos: -8.5,-9.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13393
     - type: AtmosPipeColor
@@ -65495,8 +65206,6 @@ entities:
       pos: -7.5,-4.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 13390
     - type: AtmosPipeColor
@@ -65507,8 +65216,6 @@ entities:
       pos: -15.5,-13.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
     - type: AtmosPipeColor
       color: '#E32636FF'
   - uid: 2677
@@ -65537,8 +65244,6 @@ entities:
       pos: -22.5,-11.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12961
     - type: AtmosPipeColor
@@ -65550,8 +65255,6 @@ entities:
       pos: -22.5,-22.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12961
     - type: AtmosPipeColor
@@ -65563,8 +65266,6 @@ entities:
       pos: -22.5,-30.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12961
     - type: AtmosPipeColor
@@ -65576,8 +65277,6 @@ entities:
       pos: -2.5,-25.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12953
     - type: AtmosPipeColor
@@ -65589,8 +65288,6 @@ entities:
       pos: -9.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12959
     - type: AtmosPipeColor
@@ -65602,8 +65299,6 @@ entities:
       pos: -28.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12959
     - type: AtmosPipeColor
@@ -65615,8 +65310,6 @@ entities:
       pos: -39.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12968
     - type: AtmosPipeColor
@@ -65628,8 +65321,6 @@ entities:
       pos: -51.5,-35.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12968
     - type: AtmosPipeColor
@@ -65641,8 +65332,6 @@ entities:
       pos: -52.5,-25.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12974
     - type: AtmosPipeColor
@@ -65654,8 +65343,6 @@ entities:
       pos: -62.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12981
     - type: AtmosPipeColor
@@ -65693,8 +65380,6 @@ entities:
       pos: 17.5,16.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12952
     - type: AtmosPipeColor
@@ -65706,8 +65391,6 @@ entities:
       pos: 22.5,16.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12952
     - type: AtmosPipeColor
@@ -65719,8 +65402,6 @@ entities:
       pos: -27.5,-10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12938
     - type: AtmosPipeColor
@@ -65732,8 +65413,6 @@ entities:
       pos: -38.5,-14.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12930
     - type: AtmosPipeColor
@@ -65745,8 +65424,6 @@ entities:
       pos: -48.5,-7.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
     - type: AtmosPipeColor
@@ -65757,8 +65434,6 @@ entities:
       pos: -38.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
     - type: AtmosPipeColor
@@ -65769,8 +65444,6 @@ entities:
       pos: -32.5,-5.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12937
     - type: AtmosPipeColor
@@ -65782,8 +65455,6 @@ entities:
       pos: -32.5,-22.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12939
     - type: AtmosPipeColor
@@ -65795,8 +65466,6 @@ entities:
       pos: -18.5,-24.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12995
     - type: AtmosPipeColor
@@ -65808,8 +65477,6 @@ entities:
       pos: -7.5,-24.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12995
     - type: AtmosPipeColor
@@ -65831,8 +65498,6 @@ entities:
       pos: -24.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 5661
     - type: AtmosPipeColor
@@ -65877,8 +65542,6 @@ entities:
       pos: -63.5,-33.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12984
     - type: AtmosPipeColor
@@ -65889,8 +65552,6 @@ entities:
       pos: -51.5,-20.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12974
     - type: AtmosPipeColor
@@ -66036,8 +65697,6 @@ entities:
       pos: -58.5,-38.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12983
     - type: AtmosPipeColor
@@ -66060,8 +65719,6 @@ entities:
       pos: -2.5,-9.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12953
     - type: AtmosPipeColor
@@ -66083,8 +65740,6 @@ entities:
       pos: -16.5,-37.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12959
     - type: AtmosPipeColor
@@ -66096,8 +65751,6 @@ entities:
       pos: -47.5,-14.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12921
     - type: AtmosPipeColor
@@ -66127,8 +65780,6 @@ entities:
       pos: -47.5,-10.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12936
     - type: AtmosPipeColor
@@ -66139,8 +65790,6 @@ entities:
       pos: -3.5,18.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12945
     - type: AtmosPipeColor
@@ -66152,8 +65801,6 @@ entities:
       pos: -41.5,-37.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12982
     - type: AtmosPipeColor
@@ -66181,8 +65828,6 @@ entities:
       pos: -80.5,-6.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8046
     - type: AtmosPipeColor
@@ -66194,8 +65839,6 @@ entities:
       pos: -82.5,0.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8046
     - type: AtmosPipeColor
@@ -66206,8 +65849,6 @@ entities:
       pos: -80.5,4.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 8046
     - type: AtmosPipeColor
@@ -66241,8 +65882,6 @@ entities:
       pos: -42.5,-15.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 12929
     - type: AtmosPipeColor
@@ -66322,8 +65961,6 @@ entities:
       pos: 6.5,33.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -66334,8 +65971,6 @@ entities:
       pos: 6.5,23.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -66347,8 +65982,6 @@ entities:
       pos: 7.5,30.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -66360,8 +65993,6 @@ entities:
       pos: 6.5,37.5
       parent: 2
     - type: DeviceNetwork
-      configurators:
-      - invalid
       deviceLists:
       - 6331
     - type: AtmosPipeColor
@@ -77331,7 +76962,6 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 8786
           - 8784
           - 8783
           - 1869
@@ -78971,7 +78601,7 @@ entities:
       - stampedColor: '#006600FF'
         stampedName: stamp-component-stamped-name-centcom
       content: >-
-        Совместная работа отделов повышает эффективность всех сотрудников. Попроси помощи и помоги другим и увидишь, как  тебе проще стало летать в космос. Грабеж и хамство последнее, что ты должен делать.                                                                               
+        Совместная работа отделов повышает эффективность всех сотрудников. Попроси помощи и помоги другим и увидишь, как  тебе проще стало летать в космос. Грабеж и хамство последнее, что ты должен делать.
 
 
 

--- a/Resources/Prototypes/Maps/WhiteMoose.yml
+++ b/Resources/Prototypes/Maps/WhiteMoose.yml
@@ -26,6 +26,7 @@
           ChiefMedicalOfficer: [ 1, 1 ]
           ResearchDirector: [ 1, 1 ]
           Quartermaster: [ 1, 1 ]
+          Maid: [ 1, 1 ]
           #Security
           Warden: [ 1, 1 ]
           SeniorOfficer: [ 1, 1 ]
@@ -67,4 +68,4 @@
           Boxer: [ 1, 1 ]
           Borg: [ 1, 1 ]
           Passenger: [ -1, -1 ]
-
+          Bomzh: [ 1, 0 ]

--- a/Resources/Prototypes/Maps/box.yml
+++ b/Resources/Prototypes/Maps/box.yml
@@ -29,7 +29,7 @@
             Chaplain: [ 1, 1 ]
             Librarian: [ 1, 1 ]
             ServiceWorker: [ 2, 2 ]
-            Bomzh: [ 1, 1]
+            Bomzh: [ 1, 0 ]
             #engineering
             ChiefEngineer: [ 1, 1 ]
             SeniorEngineer: [ 1, 1 ]


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR 
Пофиксил Мус, что срал 0-ым энтити.
А так же забытым модулем, что ложил карту.

## Скриншоты

## Чек-лист:

- [x] Rechecked all my code

## typo:

- [x] Fix

**Изменения**

- fix: Исправление Муса, теперь он снова работает.

**Changelog**

:cl: Warete

- fix: Исправление Муса, теперь он снова работает.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new role "Maid" with specified availability.
  - Updated role "Bomzh" to reflect new availability status.

- **Bug Fixes**
  - Removed invalid configurations for `DeviceNetwork` entities to enhance clarity and validity.

- **Chores**
  - Removed prototype entity "EightAimModule" to streamline functionality.
  - Minor text adjustments made for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->