### PR TITLE
Фикс трекинга плейтам времени бригмедика

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
+++ b/Resources/Prototypes/Catalog/Fills/Backpacks/StarterGear/backpack.yml
@@ -28,7 +28,7 @@
 
 - type: entity
   noSpawn: true
-  parent: ClothingBackpackSatchelBrigmedic
+  parent: ClothingBackpackBrigmedic
   id: ClothingBackpackBrigmedicFilled
   components:
   - type: StorageFill

--- a/Resources/Prototypes/Roles/play_time_trackers.yml
+++ b/Resources/Prototypes/Roles/play_time_trackers.yml
@@ -165,4 +165,7 @@
   id: JobBomzh
 
 - type: playTimeTracker
+  id: JobBrigmedic
+
+- type: playTimeTracker
   id: JobMaid

--- a/Resources/Prototypes/_White/Economy/salary.yml
+++ b/Resources/Prototypes/_White/Economy/salary.yml
@@ -14,6 +14,7 @@
     Bartender: 200
     Botanist: 200
     Boxer: 150
+    Brigmedic: 450
     Chaplain: 150
     Chef: 200
     Clown: 150

--- a/Resources/Prototypes/_White/Economy/salary.yml
+++ b/Resources/Prototypes/_White/Economy/salary.yml
@@ -14,7 +14,7 @@
     Bartender: 200
     Botanist: 200
     Boxer: 150
-    Brigmedic: 450
+    Brigmedic: 300
     Chaplain: 150
     Chef: 200
     Clown: 150

--- a/Resources/Prototypes/_White/Economy/salary.yml
+++ b/Resources/Prototypes/_White/Economy/salary.yml
@@ -14,7 +14,7 @@
     Bartender: 200
     Botanist: 200
     Boxer: 150
-    Brigmedic: 300
+    Brigmedic: 250
     Chaplain: 150
     Chef: 200
     Clown: 150


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR <!-- Опишите здесь ваш Pull Request. Что он изменяет? На что еще это может повлиять? -->

## Скриншоты

## Чек-лист:

- [x] Rechecked all my code

## typo:

- [x] Fix

**Изменения**

- fix: Фикс трекинга плейтам времени бригмедика.
- fix: Исправлено дублирование сумки бригмедика в его лодауте.
- fix: Исправлено отсутствие зарплаты у бригмедика

**Changelog**

:cl: ua_No_Name48237

- fix: Фикс трекинга плейтам времени бригмедика.
- fix: Исправлено дублирование сумки бригмедика в его лодауте.
- fix: Исправлено отсутствие зарплаты у бригмедика

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new play time tracker, `JobBrigmedic`, enhancing the existing list of trackers for improved role assignments and gameplay flexibility.
	- Added a new role, `Brigmedic`, with salary values of 450 and 250, expanding the game's economy and character roles.
- **Updates**
	- Modified the parent entity reference for a backpack item to streamline the inheritance structure, potentially improving interactions within the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->