### PR TITLE
Ребаланс спавна короля крыс

### DIFF
--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -183,6 +183,8 @@
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001
+    - id: MobMouse
+      prob: 0.02
 
 - type: entity
   id: CockroachMigration

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -157,6 +157,7 @@
     duration: 240
   - type: KudzuGrowthRule
 
+# Added MobMouse to specialEntries list to reduce RatKing spawn
 - type: entity
   id: MouseMigration
   parent: BaseGameRule
@@ -183,7 +184,7 @@
     specialEntries:
     - id: SpawnPointGhostRatKing
       prob: 0.001
-    - id: MobMouse
+    - id: MobMouse # WD
       prob: 0.02
 
 - type: entity


### PR DESCRIPTION
# Описание PR
**Проблема:** Слишком частый спавн гост роли короля крыс.

**Причины:** Скриншот № 1 указывает на уменьшения  начала возможности спавна ивента миграции крыс с 30 минут от начала раунда до 15 минут, а так же убран лимит игроков, необходимый для разрешения спавна ивента.
Скриншот № 2 указывает на особенность ивента миграции крыс, а точнее что он гарантирует спавн короля крыс + дополнительный шанс в 0.001, который был уменьшен с 0.005 (Скриншот №1).
В итоге ивент происходит раньше и может случаться независимо от количества игроков.

**Решение:** В прототип ивента миграции крыс была добавлена дополнительная позиция в лист "specialEntries" в виде обычной мыши. Этим простым решением был снижен эффективный спавн короля крыс на 50%.

**Заключение:** Я бля ебал думать над балансом игры, тут нужно решение от гейм дева - конкретно насколько надо уменьшить рейт спавна короля крыс. Короче пишите бля, эту мелочь подрегулировать не проблема.

## Медиа
Скриншот №1
![Screenshot_1](https://github.com/user-attachments/assets/3630e53d-e7f9-4c60-8e71-ddc3a7bb45e8)

Скриншот №2
![Screenshot_2](https://github.com/user-attachments/assets/e263386f-7244-4405-a1ef-170f985de49e)



## Тип PR
<!-- Подходите ответственно к пометке этих пунктов, для этого необходимо поставить английскую "X" между квадратных скобок -->
- [ ] Feature
- [ ] Fix
- [ ] Tweak
- [X] Balance
- [ ] Refactor
- [ ] Translate
- [ ] Resprite

**Изменения**

:cl: BIG_ZI_348
- tweak: Уменьшен спавн короля крыс.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new entity, `MobMouse`, to the game's spawning events, enhancing gameplay dynamics with a new potential spawn option.
	- Adjusted probabilities for existing and new entities, impacting the frequency of their appearance during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->