### PR TITLE
Фикс логики системы отражения

### DIFF
--- a/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
@@ -216,7 +216,7 @@ public abstract class SharedItemToggleSystem : EntitySystem
     private void TurnOnonWielded(EntityUid uid, ItemToggleComponent itemToggle, ref ItemWieldedEvent args)
     {
         if (!itemToggle.Activated)
-            TryActivate(uid, itemToggle: itemToggle);
+            TryActivate(uid, args.User, itemToggle: itemToggle); // WD added "args.User" parameter
     }
 
     public bool IsActivated(EntityUid uid, ItemToggleComponent? comp = null)
@@ -247,7 +247,7 @@ public abstract class SharedItemToggleSystem : EntitySystem
         {
             if (activeSound.ActiveSound != null && activeSound.PlayingStream == null)
             {
-                activeSound.PlayingStream = _audio.PlayPvs(activeSound.ActiveSound, uid, AudioParams.Default.WithLoop(true)) .Value.Entity;
+                activeSound.PlayingStream = _audio.PlayPvs(activeSound.ActiveSound, uid, AudioParams.Default.WithLoop(true)).Value.Entity;
             }
         }
         else

--- a/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
+++ b/Content.Shared/Item/ItemToggle/SharedItemToggleSystem.cs
@@ -247,7 +247,7 @@ public abstract class SharedItemToggleSystem : EntitySystem
         {
             if (activeSound.ActiveSound != null && activeSound.PlayingStream == null)
             {
-                activeSound.PlayingStream = _audio.PlayPvs(activeSound.ActiveSound, uid, AudioParams.Default.WithLoop(true)).Value.Entity;
+                activeSound.PlayingStream = _audio.PlayPvs(activeSound.ActiveSound, uid, AudioParams.Default.WithLoop(true)) .Value.Entity;
             }
         }
         else

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -39,6 +39,22 @@ public sealed partial class ReflectComponent : Component
     [DataField]
     public bool Innate = false;
 
+    // WD START
+    /// <summary>
+    /// If the item for reflection needed in inventory slots only - select Body.
+    /// If the item for reflection needed in hands only - select Hands.
+    /// Otherwise it will reflect in any inventory position.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite), DataField("howToUse")]
+    public Placement HowToUse = Placement.Hands | Placement.Body;
+
+    /// <summary>
+    /// Can only reflect when placed correctly.
+    /// </summary>
+    [DataField("inRightPlace"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    public bool InRightPlace = true;
+    // WD END
+
     /// <summary>
     /// Maximum probability for a projectile to be reflected.
     /// </summary>
@@ -70,4 +86,11 @@ public enum ReflectType : byte
     None = 0,
     NonEnergy = 1 << 0,
     Energy = 1 << 1,
+}
+
+public enum Placement : int
+{
+    None = 0,
+    Hands = 1,
+    Body = 2,
 }

--- a/Content.Shared/Weapons/Reflect/ReflectComponent.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectComponent.cs
@@ -45,13 +45,13 @@ public sealed partial class ReflectComponent : Component
     /// If the item for reflection needed in hands only - select Hands.
     /// Otherwise it will reflect in any inventory position.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite), DataField("howToUse")]
-    public Placement HowToUse = Placement.Hands | Placement.Body;
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public Placement Placement = Placement.Hands | Placement.Body;
 
     /// <summary>
     /// Can only reflect when placed correctly.
     /// </summary>
-    [DataField("inRightPlace"), ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
+    [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public bool InRightPlace = true;
     // WD END
 
@@ -88,9 +88,10 @@ public enum ReflectType : byte
     Energy = 1 << 1,
 }
 
-public enum Placement : int
+[Flags]
+public enum Placement : byte
 {
     None = 0,
-    Hands = 1,
-    Body = 2,
+    Hands = 1 << 0,
+    Body = 1 << 1,
 }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -290,17 +290,14 @@ public sealed class ReflectSystem : EntitySystem
 
         // WD edit start
         // Reason for the edit: previously EnableAlert and DisableAlert were given an "EntityUid uid" which
-        // belongs to an item, not to the item user.
+        // belongs to an item, not to the item user. Now its logic corrected and moved to "RefreshReflectUser()".
         // if (comp.Enabled)
         //     EnableAlert(uid);
         // else
         //     DisableAlert(uid);
         if (args.User != null)
         {
-            if (comp.Enabled && comp.InRightPlace)
-                EnableAlert((EntityUid) args.User);
-            else
-                DisableAlert((EntityUid) args.User);
+            RefreshReflectUser((EntityUid) args.User);
         }
         // WD edit end
     }
@@ -316,7 +313,19 @@ public sealed class ReflectSystem : EntitySystem
                 continue;
 
             EnsureComp<ReflectUserComponent>(user);
-            EnableAlert(user);
+
+            // WD edit start
+            // Reason for the edit: to ensure correct display of alert.
+            if (!TryComp<ReflectComponent>(ent, out var component))
+                continue;
+            if (component.Enabled && component.InRightPlace)
+                EnableAlert(user);
+            else
+            {
+                DisableAlert(user);
+                continue;
+            }
+            // WD edit end
 
             return;
         }

--- a/Content.Shared/Weapons/Reflect/ReflectSystem.cs
+++ b/Content.Shared/Weapons/Reflect/ReflectSystem.cs
@@ -211,6 +211,7 @@ public sealed class ReflectSystem : EntitySystem
     {
         if (!TryComp<ReflectComponent>(reflector, out var reflect) ||
             !reflect.Enabled ||
+            !reflect.InRightPlace || // WD
             TryComp<StaminaComponent>(reflector, out var staminaComponent) && staminaComponent.Critical ||
             _standing.IsDown(reflector))
         {
@@ -247,11 +248,7 @@ public sealed class ReflectSystem : EntitySystem
 
         EnsureComp<ReflectUserComponent>(args.Equipee);
 
-        if (component.HowToUse == Placement.Body) // WD
-            component.InRightPlace = true;
-
-        if (component.HowToUse == Placement.Hands) // WD
-            component.InRightPlace = false;
+        component.InRightPlace = IsInRightPlace(component, Placement.Body); // WD
 
         if (component.Enabled && component.InRightPlace) // WD added component.InRightPlace
             EnableAlert(args.Equipee);
@@ -268,11 +265,8 @@ public sealed class ReflectSystem : EntitySystem
             return;
 
         EnsureComp<ReflectUserComponent>(args.User);
-        if (component.HowToUse == Placement.Body) // WD
-            component.InRightPlace = false;
 
-        if (component.HowToUse == Placement.Hands) // WD
-            component.InRightPlace = true;
+        component.InRightPlace = IsInRightPlace(component, Placement.Hands); // WD
 
         if (component.Enabled && component.InRightPlace) // WD added component.InRightPlace
             EnableAlert(args.User);
@@ -342,5 +336,16 @@ public sealed class ReflectSystem : EntitySystem
     private void DisableAlert(EntityUid alertee)
     {
         _alerts.ClearAlert(alertee, AlertType.Deflecting);
+    }
+
+    /// <summary>
+    /// Selfdescribing.
+    /// </summary>
+    private static bool IsInRightPlace(ReflectComponent component, Placement placement) // WD
+    {
+        if (component.Placement == (Placement.Hands | Placement.Body))
+            return true;
+        else
+            return (component.Placement & placement) != 0x0;
     }
 }

--- a/Content.Shared/Wieldable/ItemWieldedEvent.cs
+++ b/Content.Shared/Wieldable/ItemWieldedEvent.cs
@@ -3,5 +3,23 @@ namespace Content.Shared.Wieldable;
 /// <summary>
 /// Raised directed on an entity when it is wielded.
 /// </summary>
-[ByRefEvent]
-public readonly record struct ItemWieldedEvent;
+// WD edit start
+// Reason for the edit: previously ItemWieldedEvent didn't contained "EntityUid user" parameter.
+// Now it's done like ItemUnwieldedEvent with "EntityUid user" parameter for correct logic work.
+// [ByRefEvent]
+// public readonly record struct ItemWieldedEvent;
+public sealed class ItemWieldedEvent : EntityEventArgs
+{
+    public EntityUid? User;
+    /// <summary>
+    ///     Whether the item is being forced to be wielded, or if the player chose to wield it themselves.
+    /// </summary>
+    public bool Force;
+
+    public ItemWieldedEvent(EntityUid? user = null, bool force = false)
+    {
+        User = user;
+        Force = force;
+    }
+}
+// WD edit end

--- a/Content.Shared/Wieldable/WieldableSystem.cs
+++ b/Content.Shared/Wieldable/WieldableSystem.cs
@@ -226,8 +226,8 @@ public sealed class WieldableSystem : EntitySystem
         var othersMessage = Loc.GetString("wieldable-component-successful-wield-other", ("user", user), ("item", used));
         _popupSystem.PopupPredicted(selfMessage, othersMessage, user, user);
 
-        var targEv = new ItemWieldedEvent();
-        RaiseLocalEvent(used, ref targEv);
+        var targEv = new ItemWieldedEvent(user); // WD added user
+        RaiseLocalEvent(used, targEv); // WD removed ref from targEv
 
         Dirty(used, component);
         return true;

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -108,7 +108,7 @@
   - type: Reflect
     reflectProb: 1
     innate: true # armor grants a passive shield that does not require concentration to maintain
-    howToUse:  # WD
+    placement:  # WD
       - Body
     reflects:
       - Energy

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -108,6 +108,8 @@
   - type: Reflect
     reflectProb: 1
     innate: true # armor grants a passive shield that does not require concentration to maintain
+    howToUse:  # WD
+      - Body
     reflects:
       - Energy
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -101,7 +101,7 @@
     reflectProb: 0.3
     velocityBeforeNotMaxProb: 6.0 # don't punish ninjas for being ninjas
     velocityBeforeMinProb: 10.0
-    howToUse:  # WD
+    placement:  # WD
       - Hands
   - type: MeleeBlock
     delay: 6.1

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/sword.yml
@@ -101,6 +101,8 @@
     reflectProb: 0.3
     velocityBeforeNotMaxProb: 6.0 # don't punish ninjas for being ninjas
     velocityBeforeMinProb: 10.0
+    howToUse:  # WD
+      - Hands
   - type: MeleeBlock
     delay: 6.1
 


### PR DESCRIPTION
<!-- Текст между стрелками - это комментарии - они не будут видны в вашем PR. -->

# Описание PR
Короче виздены блять насрали и я говно кое-как почистил. Если они опомнятся и сами починят, то будут конфликты, но я оставил достаточное количество комментариев. Если нам цена правильной работы отражаек выше стоимости нервов при мёрдж конфликте, то всё ок. А если нет, то блять.

## Медиа
Видео № 1 - Текущее состояние отражающих предметов:
https://github.com/user-attachments/assets/1c63ba4f-357b-483d-bd6c-f44b484c4d90
Видео № 2 - Новое состояние отражающих предметов:
https://github.com/user-attachments/assets/e6587fd1-5112-4877-bf37-51ccc8d8e7a1

## Тип PR
- [ ] Feature
- [X] Fix
- [ ] Tweak
- [ ] Balance
- [ ] Refactor
- [ ] Translate
- [ ] Resprite

**Изменения**


:cl: BIG_Zi_348
- fix: Отражающий бронежилет более не отражает лазеры будучи в руках.
- fix: Энергокатана теперь отражает снаряды только будучи в руках.
- fix: Починка отображения иконки отражения на всех соответствующих предметах.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced item activation with user context for improved interaction.
	- Added new properties to the Reflect component for clearer usage instructions and context.
	- Introduced a new enum to define item reflection states.
	- Added placement properties to armor and melee weapon configurations to specify intended usage.

- **Bug Fixes**
	- Improved logic for reflecting projectiles based on item positioning.

- **Refactor**
	- Streamlined event handling for wielding items, enhancing clarity and utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->