### PR TITLE
Revert "fix yaica"

### DIFF
--- a/Content.Client/Overlays/ShowSyndicateIconsSystem.cs
+++ b/Content.Client/Overlays/ShowSyndicateIconsSystem.cs
@@ -6,7 +6,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Client.Overlays;
 
-public sealed class ShowSyndicateIconsSystem : EquipmentHudSystem<ShowAntagonistIconsComponent>
+public sealed class ShowSyndicateIconsSystem : EquipmentHudSystem<ShowSyndicateIconsComponent>
 {
     [Dependency] private readonly IPrototypeManager _prototype = default!;
 

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -54,7 +54,7 @@ public partial class InventorySystem
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowHungerIconsComponent>>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowThirstIconsComponent>>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowMindShieldIconsComponent>>(RelayInventoryEvent);
-        SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowAntagonistIconsComponent>>(RelayInventoryEvent);
+        SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowSyndicateIconsComponent>>(RelayInventoryEvent);
         SubscribeLocalEvent<InventoryComponent, RefreshEquipmentHudEvent<ShowCriminalRecordIconsComponent>>(RelayInventoryEvent);
 
         SubscribeLocalEvent<InventoryComponent, GetVerbsEvent<EquipmentVerb>>(OnGetEquipmentVerbs);

--- a/Content.Shared/Overlays/ShowSyndicateIconsComponent.cs
+++ b/Content.Shared/Overlays/ShowSyndicateIconsComponent.cs
@@ -6,4 +6,4 @@ namespace Content.Shared.Overlays;
 ///     This component allows you to identify members of the Syndicate faction.
 /// </summary>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class ShowAntagonistIconsComponent : Component {}
+public sealed partial class ShowSyndicateIconsComponent : Component {}


### PR DESCRIPTION
Reverts frosty-dev/ss14-core#773

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Новые функции**
	- Изменена система отображения иконок на иконки синдиката, что улучшает визуализацию для игроков.
- **Исправления ошибок**
	- Обновлены подписки на события для правильного отображения иконок синдиката в интерфейсе инвентаря. 
- **Документация**
	- Переименованы компоненты для более точного отражения их назначения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->