### PR TITLE
Добавлен урон при метании кинжала-крушителя

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/knife.yml
@@ -42,10 +42,13 @@
   - type: Item
     sprite: Objects/Weapons/Melee/kitchen_knife.rsi
     storedRotation: -45
+  - type: EmbeddableProjectile # WD
+    sound: /Audio/Weapons/star_hit.ogg
   - type: DamageOtherOnHit # WD
     damage:
       types:
-        Piercing: 20
+        Piercing: 10
+        Slash: 10
   - type: GuideHelp
     guides:
     - Chef
@@ -73,6 +76,13 @@
     damage:
       types:
         Slash: 13 # WD
+  - type: EmbeddableProjectile # WD
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit # WD
+    damage:
+      types:
+        Piercing: 10
+        Slash: 13
   - type: Item
     size: Normal
     sprite: Objects/Weapons/Melee/cleaver.rsi
@@ -104,7 +114,8 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Piercing: 27 # WD
+        Piercing: 15 # WD
+        Slash: 12 # WD
   - type: Item
     sprite: Objects/Weapons/Melee/combat_knife.rsi
     storedRotation: -45
@@ -144,7 +155,8 @@
   - type: DamageOtherOnHit # WD
     damage:
       types:
-        Piercing: 44
+        Piercing: 32
+        Slash: 12
   - type: Item
     sprite: Objects/Weapons/Melee/kukri_knife.rsi
 

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -75,6 +75,13 @@
   name: crusher dagger
   description: A scaled down version of a proto-kinetic crusher. Uses kinetic energy to vibrate the blade at high speeds.
   components:
+#WD edit start
+  - type: EmbeddableProjectile
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Piercing: 15
+#WD edit end
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher_dagger.rsi
     state: icon

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -75,13 +75,6 @@
   name: crusher dagger
   description: A scaled down version of a proto-kinetic crusher. Uses kinetic energy to vibrate the blade at high speeds.
   components:
-#WD edit start
-  - type: EmbeddableProjectile
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Piercing: 15
-#WD edit end
   - type: Sprite
     sprite: Objects/Weapons/Melee/crusher_dagger.rsi
     state: icon
@@ -91,6 +84,13 @@
     attackRate: 1.5
     damage:
       types:
+        Slash: 15
+  - type: EmbeddableProjectile # WD
+    sound: /Audio/Weapons/star_hit.ogg
+  - type: DamageOtherOnHit # WD
+    damage:
+      types:
+        Piercing: 17
         Slash: 15
   - type: Tag
     tags:


### PR DESCRIPTION
# Описание PR
Добавлен урон кинжалу-крушителю при его швырянии
## Тип PR
- [X] Tweak

**Изменения**
:cl: Hero_010
- tweak: Кинжал-Крушитель может наносить урон метанием.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Новые функции**
  - Добавлен новый тип оружия: `WeaponCrusherDagger`, который наносит проникающий урон в 17 и рубящий урон в 15 при попадании.
  - Оружие оснащено компонентами `EmbeddableProjectile`, добавляющим звуковой эффект при попадании, и `DamageOtherOnHit`.
  - Обновлены механики урона для нескольких ножей, включая `KitchenKnife`, `ButchCleaver`, `CombatKnife`, `KukriKnife` и `ThrowingKnife`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->