### PR TITLE
Щиткодинг

### DIFF
--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -58,15 +58,12 @@
 #            - type: TradeStation
 #          paths:
 #            - /Maps/Shuttles/trading_outpost.yml
-        mining:
-          paths:
-          - /Maps/White/Shuttles/mining.yml
         # Spawn last
         ruins:
           hide: true
           nameGrid: true
-          minCount: 2
-          maxCount: 2
+          minCount: 43
+          maxCount: 43
           stationGrid: false
           paths:
           - /Maps/Ruins/biodome_satellite.yml
@@ -77,7 +74,42 @@
           - /Maps/Ruins/syndicate_dropship.yml
           - /Maps/Ruins/whiteship_ancient.yml
           - /Maps/Ruins/whiteship_bluespacejumper.yml
-
+          - /Maps/Salvage/asteroid-base.yml
+          - /Maps/Salvage/cargo-1.yml
+          - /Maps/Salvage/engineering-chunk.yml
+          - /Maps/Salvage/hauling-shuttle.yml
+          - /Maps/Salvage/meatball.yml
+          - /Maps/Salvage/medium-1.yml
+          - /Maps/Salvage/medium-crashed-shuttle.yml
+          - /Maps/Salvage/medium-dock.yml
+          - /Maps/Salvage/medium-library.yml
+          - /Maps/Salvage/medium-pet-hospital.yml
+          - /Maps/Salvage/medium-pirate.yml
+          - /Maps/Salvage/medium-ruined-emergency-shuttle.yml
+          - /Maps/Salvage/medium-silent-orchestra.yml
+          - /Maps/Salvage/medium-template.yml
+          - /Maps/Salvage/medium-vault-1.yml
+          - /Maps/Salvage/outpost-arm.yml
+          - /Maps/Salvage/ruin-cargo-salvage.yml
+          - /Maps/Salvage/security-chunk.yml
+          - /Maps/Salvage/small-1.yml
+          - /Maps/Salvage/small-2.yml
+          - /Maps/Salvage/small-3.yml
+          - /Maps/Salvage/small-4.yml
+          - /Maps/Salvage/small-a-1.yml
+          - /Maps/Salvage/small-ai-survey-drone.yml
+          - /Maps/Salvage/small-cargo.yml
+          - /Maps/Salvage/small-chapel.yml
+          - /Maps/Salvage/small-chef.yml
+          - /Maps/Salvage/small-party.yml
+          - /Maps/Salvage/small-ship-1.yml
+          - /Maps/Salvage/small-syndicate.yml
+          - /Maps/Salvage/small-template.yml
+          - /Maps/Salvage/small-tesla.yml
+          - /Maps/Salvage/stationstation.yml
+          - /Maps/Salvage/tick-colony.yml
+          - /Maps/Salvage/vegan-meatball.yml
+          - /Maps/Salvage/wh-salvage.yml
 - type: entity
   id: BaseStationCentcomm
   abstract: true

--- a/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
+++ b/Resources/Prototypes/InventoryTemplates/monkey_inventory_template.yml
@@ -1,60 +1,155 @@
 - type: inventoryTemplate
   id: monkey
   slots:
-  - name: head
-    slotTexture: head
-    slotFlags: HEAD
-    uiWindowPos: 1,2
-    strippingWindowPos: 0,0
-    displayName: Head
-  - name: ears
-    slotTexture: ears
-    slotFlags: EARS
-    stripTime: 3
-    uiWindowPos: 0,2
-    strippingWindowPos: 1,2
-    displayName: Ears
-  - name: mask
-    slotTexture: mask
-    slotFlags: MASK
-    uiWindowPos: 0,1
-    strippingWindowPos: 1,1
-    displayName: Mask
-  - name: jumpsuit
-    slotTexture: uniform
-    slotFlags: INNERCLOTHING
-    stripTime: 6
-    uiWindowPos: 1,0
-    strippingWindowPos: 0,2
-    displayName: Jumpsuit
-  - name: id
-    slotTexture: id
-    fullTextureName: template_small
-    slotFlags: IDCARD
-    slotGroup: SecondHotbar
-    stripTime: 6
-    uiWindowPos: 2,1
-    strippingWindowPos: 2,4
-    dependsOn: jumpsuit
-    displayName: ID
-  - name: suitstorage
-    slotTexture: suit_storage
-    slotFlags:   SUITSTORAGE
-    slotGroup: MainHotbar
-    stripTime: 3
-    uiWindowPos: 2,0
-    strippingWindowPos: 2,5
-    dependsOn: outerClothing
-    dependsOnComponents:
-    - type: AllowSuitStorage
-    displayName: Suit Storage
-  - name: outerClothing
-    slotTexture: suit
-    slotFlags: OUTERCLOTHING
-    stripTime: 6
-    uiWindowPos: 1,1
-    strippingWindowPos: 1,3
-    displayName: Suit
-    whitelist:
-      tags:
-        - MonkeyWearable
+    - name: shoes
+      slotTexture: shoes
+      slotFlags: FEET
+      stripTime: 3
+      uiWindowPos: 1,0
+      strippingWindowPos: 1,3
+      displayName: Shoes
+    - name: socks #WD slot
+      slotTexture: socks
+      slotFlags: SOCKS
+      stripTime: 6
+      uiWindowPos: 2,0
+      strippingWindowPos: 3,3
+      displayName: Socks
+      whitelist:
+        tags:
+          - socks
+    - name: underwearb #WD slot
+      slotTexture: underwearb
+      slotFlags: UNDERWEARB
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 3,2
+      displayName: Panties
+      whitelist:
+        tags:
+          - underwearb
+    - name: underweart #WD slot
+      slotTexture: underweart
+      slotFlags: UNDERWEART
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 3,1
+      displayName: Bra
+      whitelist:
+        tags:
+          - underweart
+    - name: jumpsuit
+      slotTexture: uniform
+      slotFlags: INNERCLOTHING
+      stripTime: 6
+      uiWindowPos: 0,1
+      strippingWindowPos: 0,2
+      displayName: Jumpsuit
+    - name: outerClothing
+      slotTexture: suit
+      slotFlags: OUTERCLOTHING
+      stripTime: 6
+      uiWindowPos: 1,1
+      strippingWindowPos: 1,2
+      displayName: Suit
+    - name: gloves
+      slotTexture: gloves
+      slotFlags: GLOVES
+      uiWindowPos: 2,1
+      strippingWindowPos: 2,2
+      displayName: Gloves
+    - name: neck
+      slotTexture: neck
+      slotFlags: NECK
+      uiWindowPos: 0,2
+      strippingWindowPos: 0,1
+      displayName: Neck
+    - name: mask
+      slotTexture: mask
+      slotFlags: MASK
+      uiWindowPos: 1,2
+      strippingWindowPos: 1,1
+      displayName: Mask
+    - name: eyes
+      slotTexture: glasses
+      slotFlags: EYES
+      stripTime: 3
+      uiWindowPos: 0,3
+      strippingWindowPos: 0,0
+      displayName: Eyes
+    - name: ears
+      slotTexture: ears
+      slotFlags: EARS
+      stripTime: 3
+      uiWindowPos: 2,2
+      strippingWindowPos: 2,0
+      displayName: Ears
+    - name: head
+      slotTexture: head
+      slotFlags: HEAD
+      uiWindowPos: 1,3
+      strippingWindowPos: 1,0
+      displayName: Head
+    - name: pocket1
+      slotTexture: pocket
+      fullTextureName: template_small
+      slotFlags: POCKET
+      slotGroup: MainHotbar
+      stripTime: 3
+      uiWindowPos: 0,3
+      strippingWindowPos: 0,4
+      dependsOn: jumpsuit
+      displayName: Pocket 1
+      stripHidden: true
+    - name: pocket2
+      slotTexture: pocket
+      fullTextureName: template_small
+      slotFlags: POCKET
+      slotGroup: MainHotbar
+      stripTime: 3
+      uiWindowPos: 2,3
+      strippingWindowPos: 1,4
+      dependsOn: jumpsuit
+      displayName: Pocket 2
+      stripHidden: true
+    - name: suitstorage
+      slotTexture: suit_storage
+      slotFlags:   SUITSTORAGE
+      slotGroup: SecondHotbar
+      stripTime: 3
+      uiWindowPos: 2,0
+      strippingWindowPos: 2,5
+      dependsOn: outerClothing
+      dependsOnComponents:
+      - type: AllowSuitStorage
+      displayName: Suit Storage
+    - name: id
+      slotTexture: id
+      fullTextureName: template_small
+      slotFlags: IDCARD
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 2,1
+      strippingWindowPos: 2,4
+      dependsOn: jumpsuit
+      displayName: ID
+    - name: belt
+      slotTexture: belt
+      fullTextureName: template_small
+      slotFlags: BELT
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 3,1
+      strippingWindowPos: 1,5
+      displayName: Belt
+    - name: back
+      slotTexture: back
+      fullTextureName: template_small
+      slotFlags: BACK
+      slotGroup: SecondHotbar
+      stripTime: 6
+      uiWindowPos: 3,0
+      strippingWindowPos: 0,5
+      displayName: Back
+
+

--- a/server_config.toml
+++ b/server_config.toml
@@ -1,0 +1,102 @@
+# Welcome to the example configuration file!
+# Remember that if this is in bin/Content.Server or such, it may be overwritten on build.
+# Consider copying it and using the --config-file and --data-dir options.
+
+[log]
+path = "logs"
+format = "log_%(date)s-%(time)s.txt"
+level = 1
+enabled = false
+
+[net]
+tickrate = 60
+port = 1212
+bindto = "::,0.0.0.0"
+max_connections = 256
+# Automatic port forwarding!
+# Disabled by default because you may not want to do this.
+# upnp = true
+
+[status]
+# The status server is the TCP side, used by the launcher to determine engine version, etc.
+# To be clear: Disabling it makes the launcher unable to connect!
+enabled = true
+
+# This is the address and port the status server binds to.
+# The port is by default set based on net.port so it will follow what you set there.
+# bind = "*:1212"
+
+# This is the address of the SS14 server as the launcher uses it.
+# This is only needed if you're proxying the status HTTP server -
+#  by default the launcher will assume the address and port match that of the status server.
+# connectaddress = "udp://localhost:1212"
+
+[game]
+hostname = "MyServer"
+
+[console]
+# If this is true, people connecting from this machine (loopback)
+# will automatically be elevated to full admin privileges.
+# This literally works by checking if address == 127.0.0.1 || address == ::1
+loginlocal = true
+
+[hub]
+# Set to true to show this server on the public server list
+# Before enabling this, read: https://docs.spacestation14.io/hosts/hub-rules
+advertise = false
+# Comma-separated list of tags, useful for categorizing your server.
+# See https://docs.spacestation14.io/hosts/hub-rules for more details on this when it becomes relevant.
+tags = ""
+# URL of your server. Fill this in if you have a domain name,
+# want to use HTTPS (with a reverse proxy), or other advanced scenarios.
+# Must be in the form of an ss14:// or ss14s:// URI pointing to the status API.
+server_url = ""
+# Comma-separated list of URLs of hub servers to advertise to.
+hub_urls = "https://central.spacestation14.io/hub/"
+
+[build]
+# *Absolutely all of these can be supplied using a "build.json" file*
+# For further information, see https://github.com/space-wizards/space-station-14/blob/master/Tools/gen_build_info.py
+# The main reason you'd want to supply any of these manually is for a custom fork and if you have no tools.
+
+# Useful to override if the existing version is bad.
+# See https://github.com/space-wizards/RobustToolbox/tags for version values, remove the 'v'.
+# The value listed here is almost certainly wrong - it is ONLY a demonstration of format.
+# engine_version = "0.7.6"
+
+# This one is optional, the launcher will delete other ZIPs of the same fork to save space.
+# fork_id = "abacusstation"
+
+# Automatically set if self-hosting client zip, but otherwise use this when updating client build.
+# There is no required format, any change counts as a new version.
+# version = "Example1"
+
+# This is where the launcher will download the client ZIP from.
+# If this isn't supplied, the server will check for a file called "Content.Client.zip",
+#  and will host it on the status server.
+# If that isn't available, the server will attempt to find and use "../../Resources" and
+#  "../../bin/Content.Client" to automatically construct a client zip.
+# It will then host this on the status server.
+# Note that these paths do not work on "FULL_RELEASE" servers.
+# FULL_RELEASE servers expect to be used with a specific "packaged" layout.
+# As such, whatever script you're using to package them is expected to create the ZIP.
+# download_url = "http://example.com/compass.zip"
+
+# Build hash - this is a *capitalized* SHA256 hash of the client ZIP.
+# Optional in any case and automatically set if hosting a client ZIP.
+# This hash is an example only.
+# build = "E3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855"
+
+[auth]
+# Authentication (accounts):
+# 0 = Optional, 1 = Required, 2 = Disabled
+# Presumably do require authentication on any public server.
+# mode = 0
+
+# If true, even if authentication is required, localhost is still allowed to login directly regardless.
+# allowlocal = true
+
+# You should probably never EVER need to touch this, but if you need a custom auth server,
+# (the auth server being the one which manages Space Station 14 accounts), you change it here.
+# server = https://central.spacestation14.io/auth/
+


### PR DESCRIPTION

# Описание PR
Шаттл утилизаторов удален. Обломки появляются вокруг станции раундстартом
## Тип PR
- [X] Feature
- [ ] Fix
- [ ] Tweak
- [X] Balance
- [ ] Refactor
- [ ] Translate
- [ ] Resprite

**Изменения**
1. Шаттл утилизаторов был удален из спавна.
2. Все обломки теперь спавняться вокруг станции на расстоянии 400-1000 метров.

:cl: 
- add: Добавлена генерация обломков вокруг станции.
- remove: Шаттл утилизаторов был удален.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Новые возможности**
  * Значительно расширен список возможных мест появления руин на грузовом шаттле станции за счёт добавления множества новых вариантов карт.
  * Увеличено минимальное и максимальное количество руин, которые могут появиться, с 2 до 43.
  * Существенно расширен и улучшен инвентарь персонажа "обезьяна" с добавлением новых слотов и улучшенной организацией.

* **Изменения**
  * Удалена группа "mining" из доступных групп грузового шаттла.

* **Новые файлы**
  * Добавлен пример конфигурационного файла сервера с подробными настройками и комментариями для удобства настройки.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->